### PR TITLE
change Gradient to be Send + Sync

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,7 +189,7 @@ trait GradientBase {
 
 /// The gradient
 pub struct Gradient {
-    gradient: Box<dyn GradientBase>,
+    gradient: Box<dyn GradientBase + Send + Sync>,
     dmin: f64,
     dmax: f64,
 }


### PR DESCRIPTION
Added the `Send` + `Sync` tags to the dynamic trait definition for `Gradient`. Allows for the gradient object to be used from multiple threads.