### PR TITLE
Add inverse gradient

### DIFF
--- a/src/gradient/inverse.rs
+++ b/src/gradient/inverse.rs
@@ -1,0 +1,46 @@
+use crate::Gradient;
+
+/// A gradient that inverts the gradient of another gradient.
+///
+/// The minimum value of the inner gradient will be the maximum value of the inverse gradient and
+/// vice versa.
+#[derive(Clone)]
+pub struct InverseGradient {
+    inner: Box<dyn Gradient>,
+}
+
+impl InverseGradient {
+    pub fn new(inner: Box<dyn Gradient>) -> Self {
+        Self { inner }
+    }
+}
+
+impl Gradient for InverseGradient {
+    fn at(&self, t: f32) -> crate::Color {
+        let (min, max) = self.inner.domain();
+        self.inner.at(max - t * (max - min))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::CloneGradient;
+
+    use super::*;
+
+    #[test]
+    fn inverse() {
+        let rainbow = crate::preset::rainbow();
+        let inverse = InverseGradient::new(rainbow.clone_gradient());
+
+        // Note that some inversions may not be exact due to floating point errors (E.g.
+        // `inverse.at(0.8) != rainbow.at(0.2)` at the last decimal place). If this test ever fails
+        // with values that are very close, consider changing this test to check each the float
+        // value of each color channel channel separately with an epsilon value.
+        assert_eq!(inverse.at(0.0), rainbow.at(1.0));
+        assert_eq!(inverse.at(0.3), rainbow.at(0.7));
+        assert_eq!(inverse.at(0.5), rainbow.at(0.5));
+        assert_eq!(inverse.at(0.7), rainbow.at(0.3));
+        assert_eq!(inverse.at(1.0), rainbow.at(0.0));
+    }
+}

--- a/src/gradient/mod.rs
+++ b/src/gradient/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod basis;
 pub(crate) mod catmull_rom;
+pub(crate) mod inverse;
 pub(crate) mod linear;
 pub(crate) mod sharp;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,7 @@ mod css_gradient;
 mod gradient;
 pub use gradient::basis::BasisGradient;
 pub use gradient::catmull_rom::CatmullRomGradient;
+pub use gradient::inverse::InverseGradient;
 pub use gradient::linear::LinearGradient;
 pub use gradient::sharp::SharpGradient;
 
@@ -217,6 +218,22 @@ pub trait Gradient: CloneGradient {
         };
         SharpGradient::new(&colors, self.domain(), smoothness)
     }
+
+    /// Get a new gradient that inverts the gradient
+    ///
+    /// The minimum value of the inner gradient will be the maximum value of the inverse gradient and
+    /// vice versa.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use colorgrad::Gradient;
+    /// let rainbow = colorgrad::preset::rainbow();
+    /// let inverse = rainbow.inverse();
+    /// ```
+    fn inverse(&self) -> InverseGradient {
+        InverseGradient::new(self.clone_gradient())
+    }
 }
 
 pub trait CloneGradient {
@@ -284,5 +301,16 @@ mod tests {
         assert_eq!(linspace(0.0, 1.0, 3), vec![0.0, 0.5, 1.0]);
         assert_eq!(linspace(-1.0, 1.0, 5), vec![-1.0, -0.5, 0.0, 0.5, 1.0]);
         assert_eq!(linspace(0.0, 100.0, 5), vec![0.0, 25.0, 50.0, 75.0, 100.0]);
+    }
+
+    #[test]
+    fn inverse() {
+        let rainbow = preset::rainbow();
+        let inverse = rainbow.inverse();
+
+        // Note that this test is just to make sure the inverse trait method is working correctly.
+        // The values are properly tested in the inverse module tests.
+        assert_eq!(inverse.at(0.0), rainbow.at(1.0));
+        assert_eq!(inverse.at(1.0), rainbow.at(0.0));
     }
 }


### PR DESCRIPTION
Adds a new InverseGradient, which reverses the domain of any existing
gradient implentation. Adds a new inverse() method to the Gradient trait
which returns the inverted gradient.

Fixes: https://github.com/mazznoer/colorgrad-rs/issues/11
