### PR TITLE
Implement Gradient trait on Box<impl Gradient>

### DIFF
--- a/src/gradient/boxed.rs
+++ b/src/gradient/boxed.rs
@@ -1,0 +1,54 @@
+use csscolorparser::Color;
+
+use crate::{Gradient, SharpGradient};
+
+impl Gradient for Box<dyn Gradient> {
+    fn at(&self, t: f32) -> crate::Color {
+        (**self).at(t)
+    }
+
+    fn repeat_at(&self, t: f32) -> Color {
+        (**self).repeat_at(t)
+    }
+
+    fn reflect_at(&self, t: f32) -> Color {
+        (**self).reflect_at(t)
+    }
+
+    fn domain(&self) -> (f32, f32) {
+        (**self).domain()
+    }
+
+    fn colors(&self, n: usize) -> Vec<Color> {
+        (**self).colors(n)
+    }
+
+    fn sharp(&self, segment: u16, smoothness: f32) -> SharpGradient {
+        (**self).sharp(segment, smoothness)
+    }
+
+    fn boxed(self) -> Box<dyn Gradient>
+    where
+        Self: 'static,
+    {
+        Box::new(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::preset;
+
+    use super::*;
+
+    #[test]
+    fn boxed_gradients() {
+        let gradient = preset::rainbow().boxed();
+        assert_eq!(gradient.at(0.0).to_rgba8(), [110, 64, 170, 255]);
+        assert_eq!(gradient.repeat_at(1.25).to_rgba8(), [255, 94, 99, 255]);
+        assert_eq!(gradient.reflect_at(1.25).to_rgba8(), [77, 199, 194, 255]);
+        assert_eq!(gradient.domain(), (0.0, 1.0));
+        assert_eq!(gradient.colors(3).len(), 3);
+        assert_eq!(gradient.sharp(3, 0.0).colors(3).len(), 3);
+    }
+}

--- a/src/gradient/mod.rs
+++ b/src/gradient/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod basis;
+pub(crate) mod boxed;
 pub(crate) mod catmull_rom;
 pub(crate) mod linear;
 pub(crate) mod sharp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,6 +217,27 @@ pub trait Gradient: CloneGradient {
         };
         SharpGradient::new(&colors, self.domain(), smoothness)
     }
+
+    /// Convert gradient to boxed trait object
+    ///
+    /// This is a convenience function, which is useful when you want to store gradients with
+    /// different types in a collection, or when you want to return a gradient from a function but
+    /// the type is not known at compile time.
+    ///
+    /// ```
+    /// # let is_rainbow = true;
+    /// let g = if is_rainbow {
+    ///     colorgrad::preset::rainbow().boxed()
+    /// } else {
+    ///     colorgrad::preset::sinebow().boxed()
+    /// };
+    /// ```
+    fn boxed(self) -> Box<dyn Gradient>
+    where
+        Self: Sized + 'static,
+    {
+        Box::new(self)
+    }
 }
 
 pub trait CloneGradient {


### PR DESCRIPTION
This simplifies code where the specific gradient type in use is not
known at compile time, but you still want to store it or return it from
a function.

Additionally this adds a convenience method `boxed` to the Gradient
trait. This simplifies the conversion of a gradient to a boxed trait
object without having to write out the full Box<Gradient> type.

```rust
// type is not known at compile time
let gradient = match gradient_type {
    GradientType::Rainbow => preset::rainbow().boxed(),
    GradientType::Sinebow => preset::sinebow().boxed(),
};

// store gradients with different types in a collection
let gradients: Vec<Box<dyn Gradient>> = vec![
    preset::rainbow().boxed(),
    preset::sinebow().boxed(),
];

// store gradient in a struct
struct SomeWidget {
    gradient: Box<dyn Gradient>,
}

impl SomeWidget {
    fn fg(&self) -> Color {
        self.gradient.at(0.5)
    }
}
```
